### PR TITLE
Keeping the cart in local storage

### DIFF
--- a/client/src/stores/modules/cart.js
+++ b/client/src/stores/modules/cart.js
@@ -1,0 +1,23 @@
+function saveCart(cart) {
+  localStorage.cart = JSON.stringify(cart);
+}
+
+function loadCart() {
+  if (localStorage.cart) {
+    return JSON.parse(localStorage.cart);
+  } else {
+    return [];
+  }
+}
+
+export default {
+  state: {
+    cart: loadCart()
+  },
+  mutations: {
+    addToCart(state, item){
+        state.cart.push(item);
+        saveCart(state.cart);
+    }
+  }
+};

--- a/client/src/stores/store.js
+++ b/client/src/stores/store.js
@@ -2,20 +2,17 @@ import Vue from 'vue'
 import Vuex from 'vuex'
 import axios from 'axios'
 const jwt = require('jsonwebtoken');
+import cartStoreModule from './modules/cart.js'
 
 Vue.use(Vuex)
 
 const store = new Vuex.Store({
   state: {
-    cart:[],
     status: '',
     token: window.$cookies.get('auth') || '',
     user: jwt.decode(window.$cookies.get('auth'))
   },
   mutations: {
-    addToCart(state, item){
-        state.cart.push(item);
-    },
     auth_request(state) {
       state.status = 'loading'
     },
@@ -61,6 +58,9 @@ const store = new Vuex.Store({
     isLoggedIn: state => !!state.token,
     authStatus: state => state.status,
     user: state => state.user
+  },
+  modules: {
+    cartStoreModule
   }
 })
 


### PR DESCRIPTION
I broke the logic for the cart out into another store module to help reduce clutter a bit and help keep common store code wrapped up in concise files.

The behavior is mostly the same, but any time something is added to the cart this will update the localStorage. And any time a user loads the page, the Vuex store will try to load the cart from the browsers localStorage.