### PR TITLE
Increasing cart quantities of duplicate items

### DIFF
--- a/client/src/stores/modules/cart.js
+++ b/client/src/stores/modules/cart.js
@@ -12,7 +12,12 @@ export default {
   },
   mutations: {
     addToCart(state, item){
-      state.cart.push(item);
+      let existingItem = state.cart.find(cartItem => cartItem.partnumber == item.partnumber);
+      if (existingItem) {
+        existingItem.qty += item.qty;
+      } else {
+        state.cart.push(item);
+      }
       saveCart(state.cart);
     },
     removeFromCart(state, item){


### PR DESCRIPTION
This updates the cart store to detect if a duplicate part number is being added to the cart and increasing the quantity of the existing item if needed.